### PR TITLE
Fix decode issue

### DIFF
--- a/src/cdecode.c
+++ b/src/cdecode.c
@@ -22,6 +22,16 @@ void base64_init_decodestate(base64_decodestate* state_in)
 	state_in->plainchar = 0;
 }
 
+int is_next_codechar_anequal(const char* code_in_next, const int length_in_remaining)
+{
+	// Do we have any characters remaining after this one?
+	if (length_in_remaining) {
+		if (*code_in_next == '=')
+			return (1); // We have an equal
+	}
+	return (0); // No more charcters available
+}
+
 int base64_decode_block(const char* code_in, const int length_in, char* plaintext_out, base64_decodestate* state_in)
 {
 	const char* codechar = code_in;
@@ -56,7 +66,8 @@ int base64_decode_block(const char* code_in, const int length_in, char* plaintex
 				fragment = (char)base64_decode_value(*codechar++);
 			} while (fragment < 0);
 			*plainchar++ |= (fragment & 0x030) >> 4;
-			*plainchar    = (fragment & 0x00f) << 4;
+			if (!is_next_codechar_anequal(codechar, length_in - (codechar - code_in)))
+				*plainchar    = (fragment & 0x00f) << 4;
 	case step_c:
 			do {
 				if (codechar == code_in+length_in)
@@ -68,7 +79,8 @@ int base64_decode_block(const char* code_in, const int length_in, char* plaintex
 				fragment = (char)base64_decode_value(*codechar++);
 			} while (fragment < 0);
 			*plainchar++ |= (fragment & 0x03c) >> 2;
-			*plainchar    = (fragment & 0x003) << 6;
+			if (!is_next_codechar_anequal(codechar, length_in - (codechar - code_in)))
+				*plainchar    = (fragment & 0x003) << 6;
 	case step_d:
 			do {
 				if (codechar == code_in+length_in)


### PR DESCRIPTION
In base64_decode_block(), step_b & step_c have a bug in that they will cause bits of the next byte to be written even though there are no more bytes in the encoded data. This adds an additional check for more encoded data before writing the additional bits to the next byte.

Additional Information:
The encoder encodes data in 3 byte groups into 4 Base64 characters. If the data being encoded is not a multiple of 3 bytes then the encoder will append = characters in the Base64 data. Therefore you may end up with Base64 data that contains one or more trailing = characters. 

When decoding the data the = characters are ignored however the bug in the decoder automatically writes any remaining bits in the current step into the next byte position even if the encoded data has no more bits. Which causes bits outside of the actual encoded data to be modified unexpectedly.